### PR TITLE
DaisyUI -> CSS Frameworks [Removed]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -633,7 +633,6 @@
 | [Pico.css](https://picocss.com/) | Elegant styles for all natives HTML elements without .classes and dark mode automatically enabled. |
 | [clay.css](https://github.com/codeAdrian/clay.css) | Extensible and configurable micro CSS util class and SASS mixin for adding claymorphism styles to your components. |
 | [BeerCSS](https://www.beercss.com) | Build Material Design interfaces in record time, without stress for devs 🍻. The first CSS framework that implements Material Design 3. |
-| [daisyUI](https://daisyui.com/) | Tons of components use with Tailwind CSS but write fewer class names. |
 | [UnoCSS](https://unocss.dev/) | UnoCSS is the instant atomic CSS engine, that is designed to be flexible and extensible. The core is un-opinionated, and all the CSS utilities are provided via presets. |
 | [Neptune CSS](neptunecss.org) | Neptune CSS is a lightweight CSS framework. Use it to develop your websites faster. |
 | [StyleX](https://stylexjs.com/) | StyleX is a simple, easy-to-use JavaScript syntax and compiler for styling web apps. |


### PR DESCRIPTION

# Resource Name - DaisyUI
Removed DaisyUI from the Frameworks section because it's already in UI Components & Kits which is the correct section.


Link: [www.linkToResource](https://daisyui.com/)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
